### PR TITLE
Fix the compile-fail tests, as of rust 1.52.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ system-lua = ["pkg-config"]
 
 [dependencies]
 libc = { version = "0.2" }
-num-traits = { version = "0.2.6" }
+num-traits = { version = "0.2.14" }
 bitflags = { version = "1.0.4" }
 bstr = {version = "0.2", features = ["std"], default_features = false }
 

--- a/tests/compile-fail/context_nounwindsafe.rs
+++ b/tests/compile-fail/context_nounwindsafe.rs
@@ -7,7 +7,7 @@ use rlua::Lua;
 fn main() {
     Lua::new().context(|lua| {
         catch_unwind(move || {
-            //~^ error: the type `std::cell::UnsafeCell<()>` may contain interior mutability and a reference
+            //~^ error: the type `UnsafeCell<()>` may contain interior mutability and a reference
             // may not be safely transferrable across a catch_unwind boundary
             lua.create_table().unwrap();
         });

--- a/tests/compile-fail/lua_norefunwindsafe.rs
+++ b/tests/compile-fail/lua_norefunwindsafe.rs
@@ -7,7 +7,7 @@ use rlua::Lua;
 fn main() {
     let lua = Lua::new();
     catch_unwind(|| {
-        //~^ error: the type `std::cell::UnsafeCell<()>` may contain interior mutability and a reference
+        //~^ error: the type `UnsafeCell<()>` may contain interior mutability and a reference
         // may not be safely transferrable across a catch_unwind boundary
         lua.context(|lua| {
             lua.create_table().unwrap();

--- a/tests/compile-fail/scope_callback_capture.rs
+++ b/tests/compile-fail/scope_callback_capture.rs
@@ -11,9 +11,8 @@ fn main() {
         lua.scope(|scope| {
             let mut inner: Option<Table> = None;
             let f = scope
+                //~^ error: borrowed data escapes outside of closure
                 .create_function_mut(move |lua, t: Table| {
-                    //~^ error: cannot infer an appropriate lifetime for autoref due to conflicting
-                    // requirements
                     if let Some(old) = inner.take() {
                         // Access old callback `Lua`.
                     }

--- a/tests/compile-fail/scope_callback_inner.rs
+++ b/tests/compile-fail/scope_callback_inner.rs
@@ -11,9 +11,9 @@ fn main() {
         lua.scope(|scope| {
             let mut inner: Option<Table> = None;
             let f = scope
+                //~^ error: borrowed data escapes outside of closure
                 .create_function_mut(|_, t: Table| {
-                    //~^ error: cannot infer an appropriate lifetime for autoref due to conflicting
-                    // requirements
+                    //~^ error: closure may outlive the current function, but it borrows `inner`
                     inner = Some(t);
                     Ok(())
                 })

--- a/tests/compile-fail/scope_callback_outer.rs
+++ b/tests/compile-fail/scope_callback_outer.rs
@@ -11,9 +11,10 @@ fn main() {
         let mut outer: Option<Table> = None;
         lua.scope(|scope| {
             let f = scope
+                //~^ error: borrowed data escapes outside of closure
                 .create_function_mut(|_, t: Table| {
-                    //~^^ error: borrowed data cannot be stored outside of its closure
                     outer = Some(t);
+                    //~^ error: `outer` does not live long enough
                     Ok(())
                 })
                 .unwrap();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -428,7 +428,8 @@ fn test_num_conversion() {
             lua.unpack::<f64>(lua.pack(f32::MAX).unwrap()).unwrap(),
             f32::MAX as f64
         );
-        assert!(lua.unpack::<f32>(lua.pack(f64::MAX).unwrap()).is_err());
+        assert!(dbg!(lua.unpack::<f32>(lua.pack(f64::MAX).unwrap())).is_err());
+        assert!(false);
 
         assert_eq!(
             lua.unpack::<i128>(lua.pack(1i128 << 64).unwrap()).unwrap(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -428,8 +428,7 @@ fn test_num_conversion() {
             lua.unpack::<f64>(lua.pack(f32::MAX).unwrap()).unwrap(),
             f32::MAX as f64
         );
-        assert!(dbg!(lua.unpack::<f32>(lua.pack(f64::MAX).unwrap())).is_err());
-        assert!(false);
+        assert!(lua.unpack::<f32>(lua.pack(f64::MAX).unwrap()).is_err());
 
         assert_eq!(
             lua.unpack::<i128>(lua.pack(1i128 << 64).unwrap()).unwrap(),

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -10,8 +10,8 @@ fn test_user_data() {
     struct UserData1(i64);
     struct UserData2(Box<i64>);
 
-    impl UserData for UserData1 {};
-    impl UserData for UserData2 {};
+    impl UserData for UserData1 {}
+    impl UserData for UserData2 {}
 
     Lua::new().context(|lua| {
         let userdata1 = lua.create_userdata(UserData1(1)).unwrap();


### PR DESCRIPTION
The compiler error messages have improved.
Also fix a warning in the userdata tests.

Fixes #207 .