### PR TITLE
add feature for LUA_COMPAT_MATHLIB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ builtin-lua = ["cc"]
 # the final binary manually.  The builtin-lua and system-lua features are
 # mutually exclusive and enabling both will cause an error at build time.
 system-lua = ["pkg-config"]
+# Enabled functions from the math module that have been deprecated
+lua-compat-mathlib = []
+
 
 [dependencies]
 libc = { version = "0.2" }

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,9 @@ fn main() {
         if cfg!(debug_assertions) {
             config.define("LUA_USE_APICHECK", None);
         }
+        if cfg!(feature = "lua-compat-mathlib") {
+            config.define("LUA_COMPAT_MATHLIB", None);
+        }
 
         config
             .include("lua")


### PR DESCRIPTION
The primary motivator for this change is to allow for this value when running the current 0.17.0 which is tied to lua 5.3. Addresses #99 