### PR TITLE
chore: update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rlua"
 version = "0.18.0"
 authors = ["kyren <kerriganw@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "High level bindings to Lua 5.x"
 repository = "https://github.com/amethyst/rlua"
 documentation = "https://docs.rs/rlua"


### PR DESCRIPTION
on line 390 in conversion.rs `lua.create_sequence_from` accepts an array by value that implement into_iterator. this feature is only available in 2021 unless this is changed to support stable versions of rust. its not possible to build this in 2018.

https://doc.rust-lang.org/std/primitive.array.html