### PR TITLE
fix: build for stable channel rust

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -392,7 +392,7 @@ lua_convert_float!(f64);
 
 impl<'lua, T: ToLua<'lua>, const N: usize> ToLua<'lua> for [T; N] {
     fn to_lua(self, lua: Context<'lua>) -> Result<Value<'lua>> {
-        Ok(Value::Table(lua.create_sequence_from(vec![self])?))
+        Ok(Value::Table(lua.create_sequence_from(Vec::from(self))?))
     }
 }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -392,7 +392,7 @@ lua_convert_float!(f64);
 
 impl<'lua, T: ToLua<'lua>, const N: usize> ToLua<'lua> for [T; N] {
     fn to_lua(self, lua: Context<'lua>) -> Result<Value<'lua>> {
-        Ok(Value::Table(lua.create_sequence_from(self)?))
+        Ok(Value::Table(lua.create_sequence_from(vec![self])?))
     }
 }
 


### PR DESCRIPTION
this allows the build to work on stable versions of rust. `into_iter()` for array is implemented for `https://doc.rust-lang.org/std/primitive.array.html` 2021 version of rust. 