### PR TITLE
Add unit tests for some conversions (thanks to @pollend)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -19,10 +19,13 @@ use crate::types::{Callback, Integer, LightUserData, LuaRef, Number, RegistryKey
 use crate::userdata::{AnyUserData, MetaMethod, UserData, UserDataMethods};
 use crate::util::{
     assert_stack, callback_error, check_stack, get_userdata, get_wrapped_error,
-    init_userdata_metatable, isluainteger, loadbufferx, pop_error, protect_lua,
+    init_userdata_metatable, loadbufferx, pop_error, protect_lua,
     protect_lua_closure, push_globaltable, push_string, push_userdata_uv, push_wrapped_error,
     tointegerx, tonumberx, StackGuard,
 };
+#[cfg(any(rlua_lua53,rlua_lua54))]
+use crate::util::isluainteger;
+
 use crate::value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
 
 #[derive(Copy, Clone, Debug)]
@@ -304,6 +307,7 @@ impl<'lua> Context<'lua> {
     /// Lua manual for details.
     pub fn coerce_integer(self, v: Value<'lua>) -> Result<Option<Integer>> {
         Ok(match v {
+            #[cfg(any(rlua_lua53,rlua_lua54))]
             Value::Integer(i) => Some(i),
             v => unsafe {
                 let _sg = StackGuard::new(self.state);
@@ -552,6 +556,7 @@ impl<'lua> Context<'lua> {
                 ffi::lua_pushlightuserdata(self.state, ud.0);
             }
 
+            #[cfg(any(rlua_lua53,rlua_lua54))]
             Value::Integer(i) => {
                 ffi::lua_pushinteger(self.state, i);
             }
@@ -609,6 +614,13 @@ impl<'lua> Context<'lua> {
             }
 
             ffi::LUA_TNUMBER => {
+                #[cfg(any(rlua_lua51))]
+                {
+                    let n = Value::Number(ffi::lua_tonumber(self.state, -1));
+                    ffi::lua_pop(self.state, 1);
+                    n
+                }
+                #[cfg(any(rlua_lua53,rlua_lua54))]
                 if isluainteger(self.state, -1) != 0 {
                     let i = Value::Integer(ffi::lua_tointeger(self.state, -1));
                     ffi::lua_pop(self.state, 1);

--- a/src/context.rs
+++ b/src/context.rs
@@ -17,14 +17,14 @@ use crate::table::Table;
 use crate::thread::Thread;
 use crate::types::{Callback, Integer, LightUserData, LuaRef, Number, RegistryKey};
 use crate::userdata::{AnyUserData, MetaMethod, UserData, UserDataMethods};
+#[cfg(any(rlua_lua53, rlua_lua54))]
+use crate::util::isluainteger;
 use crate::util::{
     assert_stack, callback_error, check_stack, get_userdata, get_wrapped_error,
-    init_userdata_metatable, loadbufferx, pop_error, protect_lua,
-    protect_lua_closure, push_globaltable, push_string, push_userdata_uv, push_wrapped_error,
-    tointegerx, tonumberx, StackGuard,
+    init_userdata_metatable, loadbufferx, pop_error, protect_lua, protect_lua_closure,
+    push_globaltable, push_string, push_userdata_uv, push_wrapped_error, tointegerx, tonumberx,
+    StackGuard,
 };
-#[cfg(any(rlua_lua53,rlua_lua54))]
-use crate::util::isluainteger;
 
 use crate::value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
 
@@ -307,7 +307,7 @@ impl<'lua> Context<'lua> {
     /// Lua manual for details.
     pub fn coerce_integer(self, v: Value<'lua>) -> Result<Option<Integer>> {
         Ok(match v {
-            #[cfg(any(rlua_lua53,rlua_lua54))]
+            #[cfg(any(rlua_lua53, rlua_lua54))]
             Value::Integer(i) => Some(i),
             v => unsafe {
                 let _sg = StackGuard::new(self.state);
@@ -556,7 +556,7 @@ impl<'lua> Context<'lua> {
                 ffi::lua_pushlightuserdata(self.state, ud.0);
             }
 
-            #[cfg(any(rlua_lua53,rlua_lua54))]
+            #[cfg(any(rlua_lua53, rlua_lua54))]
             Value::Integer(i) => {
                 ffi::lua_pushinteger(self.state, i);
             }
@@ -620,7 +620,7 @@ impl<'lua> Context<'lua> {
                     ffi::lua_pop(self.state, 1);
                     n
                 }
-                #[cfg(any(rlua_lua53,rlua_lua54))]
+                #[cfg(any(rlua_lua53, rlua_lua54))]
                 if isluainteger(self.state, -1) != 0 {
                     let i = Value::Integer(ffi::lua_tointeger(self.state, -1));
                     ffi::lua_pop(self.state, 1);

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -292,7 +292,7 @@ macro_rules! lua_convert_int {
                 if let Some(i) = cast(self) {
                     #[cfg(rlua_lua51)]
                     let result = Ok(Value::Number(i));
-                    #[cfg(any(rlua_lua53,rlua_lua54))]
+                    #[cfg(any(rlua_lua53, rlua_lua54))]
                     let result = Ok(Value::Integer(i));
 
                     result

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -290,7 +290,12 @@ macro_rules! lua_convert_int {
         impl<'lua> ToLua<'lua> for $x {
             fn to_lua(self, _: Context<'lua>) -> Result<Value<'lua>> {
                 if let Some(i) = cast(self) {
-                    Ok(Value::Integer(i))
+                    #[cfg(rlua_lua51)]
+                    let result = Ok(Value::Number(i));
+                    #[cfg(any(rlua_lua53,rlua_lua54))]
+                    let result = Ok(Value::Integer(i));
+
+                    result
                 } else {
                     cast(self)
                         .ok_or_else(|| Error::ToLuaConversionError {

--- a/src/util.rs
+++ b/src/util.rs
@@ -556,13 +556,6 @@ pub unsafe fn tonumberx(
 #[cfg(any(rlua_lua53, rlua_lua54))]
 pub use ffi::lua_isinteger as isluainteger;
 
-#[cfg(rlua_lua51)]
-// Implementation of `lua_isinteger()` for Lua 5.1
-pub unsafe fn isluainteger(_state: *mut ffi::lua_State, _index: c_int) -> c_int {
-    // Lua 5.1 doesn't support integers
-    0
-}
-
 #[cfg(any(rlua_lua53, rlua_lua54))]
 pub use ffi::lua_rotate as rotate;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,9 +7,9 @@ use crate::function::Function;
 use crate::string::String;
 use crate::table::Table;
 use crate::thread::Thread;
-use crate::types::{LightUserData, Number};
-#[cfg(any(rlua_lua53,rlua_lua54))]
+#[cfg(any(rlua_lua53, rlua_lua54))]
 use crate::types::Integer;
+use crate::types::{LightUserData, Number};
 use crate::userdata::AnyUserData;
 
 /// A dynamically typed Lua value.  The `String`, `Table`, `Function`, `Thread`, and `UserData`
@@ -24,7 +24,7 @@ pub enum Value<'lua> {
     Boolean(bool),
     /// A "light userdata" object, equivalent to a raw pointer.
     LightUserData(LightUserData),
-    #[cfg(any(rlua_lua53,rlua_lua54))]
+    #[cfg(any(rlua_lua53, rlua_lua54))]
     /// An integer number.
     ///
     /// Any Lua number convertible to a `Integer` will be represented as this variant.
@@ -56,7 +56,7 @@ impl<'lua> Value<'lua> {
             Value::Nil => "nil",
             Value::Boolean(_) => "boolean",
             Value::LightUserData(_) => "lightuserdata",
-            #[cfg(any(rlua_lua53,rlua_lua54))]
+            #[cfg(any(rlua_lua53, rlua_lua54))]
             Value::Integer(_) => "integer",
             Value::Number(_) => "number",
             Value::String(_) => "string",

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,7 +7,9 @@ use crate::function::Function;
 use crate::string::String;
 use crate::table::Table;
 use crate::thread::Thread;
-use crate::types::{Integer, LightUserData, Number};
+use crate::types::{LightUserData, Number};
+#[cfg(any(rlua_lua53,rlua_lua54))]
+use crate::types::Integer;
 use crate::userdata::AnyUserData;
 
 /// A dynamically typed Lua value.  The `String`, `Table`, `Function`, `Thread`, and `UserData`
@@ -22,9 +24,11 @@ pub enum Value<'lua> {
     Boolean(bool),
     /// A "light userdata" object, equivalent to a raw pointer.
     LightUserData(LightUserData),
+    #[cfg(any(rlua_lua53,rlua_lua54))]
     /// An integer number.
     ///
     /// Any Lua number convertible to a `Integer` will be represented as this variant.
+    /// (Lua 5.3+ only)
     Integer(Integer),
     /// A floating point number.
     Number(Number),
@@ -52,6 +56,7 @@ impl<'lua> Value<'lua> {
             Value::Nil => "nil",
             Value::Boolean(_) => "boolean",
             Value::LightUserData(_) => "lightuserdata",
+            #[cfg(any(rlua_lua53,rlua_lua54))]
             Value::Integer(_) => "integer",
             Value::Number(_) => "number",
             Value::String(_) => "string",

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -1,67 +1,66 @@
-use rlua::{Lua, ToLua, Value, Result, Table, Error, String};
+use rlua::{Integer, Lua, Result, String, Table, ToLua, Value};
 
-fn validate_float(verify: Result<Value>, expected: f64) {
+fn valid_float(verify: Result<Value>, expected: f64) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "number");
     match verify_unwrap {
         Value::Number(value) => assert_eq!(value, expected),
-        _ => assert!(false, "unexpected type"),
+        _ => panic!("unexpected type"),
     };
 }
 
-fn valid_int(verify: Result<Value>, expected: i64) {
+fn valid_int(verify: Result<Value>, expected: Integer) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "integer");
     match verify_unwrap {
         Value::Integer(value) => assert_eq!(value, expected),
-        _ => assert!(false, "unexpected type"),
+        _ => panic!("unexpected type"),
     };
 }
 
 fn valid_table(verify: Result<Value>, handler: fn(tbl: Table)) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "table");
-    match  verify_unwrap {
+    match verify_unwrap {
         Value::Table(value) => handler(value),
-        _ =>  assert!(false, "unexpected type"),
+        _ => panic!("unexpected type"),
     };
 }
 
 fn valid_string(verify: Result<Value>, val: String) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "string");
-    match  verify_unwrap {
+    match verify_unwrap {
         Value::String(value) => assert_eq!(value, val),
-        _ =>  assert!(false, "unexpected type"),
+        _ => panic!("unexpected type"),
     };
 }
 
 fn valid_boolean(verify: Result<Value>, val: bool) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "boolean");
-    match  verify_unwrap {
+    match verify_unwrap {
         Value::Boolean(value) => assert_eq!(value, val),
-        _ =>  assert!(false, "unexpected type"),
+        _ => panic!("unexpected type"),
     };
 }
-
 
 #[test]
 fn test_conversion_int_primitives() {
     let lua = Lua::new();
 
-    let v :i8 = 10;
-    let v2 :u8 = 10;
-    let v3 :i16 = 10;
-    let v4 :u16 = 10;
-    let v5 :i32 = 10;
-    let v6 :u32 = 10;
-    let v7 :i64 = 10;
-    let v8 :u64 = 10;
-    let v9 :i128 = 10;
-    let v10 :u128 = 10;
-    let v11 :isize = 10;
-    let v12 :usize = 10;
+    let v: i8 = 10;
+    let v2: u8 = 10;
+    let v3: i16 = 10;
+    let v4: u16 = 10;
+    let v5: i32 = 10;
+    let v6: u32 = 10;
+    let v7: i64 = 10;
+    let v8: u64 = 10;
+    let v9: i128 = 10;
+    let v10: u128 = 10;
+    let v11: isize = 10;
+    let v12: usize = 10;
 
     lua.context(|ctx| {
         valid_int(v.to_lua(ctx), 10);
@@ -79,47 +78,43 @@ fn test_conversion_int_primitives() {
     });
 }
 
-
-
 #[test]
 fn test_conversion_float_primatives() {
     let lua = Lua::new();
 
-    let v :f32 = 10.0;
-    let v2 :f64 = 10.0;
+    let v: f32 = 10.0;
+    let v2: f64 = 10.0;
 
     lua.context(|ctx| {
-        validate_float(v.to_lua(ctx), 10.0);
-        validate_float(v2.to_lua(ctx), 10.0);
+        valid_float(v.to_lua(ctx), 10.0);
+        valid_float(v2.to_lua(ctx), 10.0);
     });
 }
 
-
 #[test]
 fn test_conversion_int_array_table() {
+    let v1: [u32; 3] = [10, 15, 4];
+    let v2: [u8; 3] = [10, 15, 4];
+    let v3: [i16; 3] = [10, 15, 4];
+    let v4: [u16; 3] = [10, 15, 4];
+    let v5: [i32; 3] = [10, 15, 4];
+    let v6: [u32; 3] = [10, 15, 4];
+    let v7: [i64; 3] = [10, 15, 4];
+    let v8: [u64; 3] = [10, 15, 4];
+    let v9: [i128; 3] = [10, 15, 4];
+    let v10: [u128; 3] = [10, 15, 4];
+    let v11: [isize; 3] = [10, 15, 4];
+    let v12: [usize; 3] = [10, 15, 4];
 
-    let v1 : [u32; 3] = [10,15,4];
-    let v2 : [u8; 3] = [10,15,4];
-    let v3 : [i16; 3] = [10,15,4];
-    let v4 : [u16; 3] = [10,15,4];
-    let v5 : [i32; 3] = [10,15,4];
-    let v6 : [u32; 3] = [10,15,4];
-    let v7 : [i64; 3] = [10,15,4];
-    let v8 : [u64; 3] = [10,15,4];
-    let v9 : [i128; 3] = [10,15,4];
-    let v10 : [u128; 3] = [10,15,4];
-    let v11 : [isize; 3] = [10,15,4];
-    let v12 : [usize; 3] = [10,15,4];
-
-    let v1f : [f32; 3] = [10.0,15.0,4.0];
-    let v2f : [f64; 3] = [10.0,15.0,4.0];
+    let v1f: [f32; 3] = [10.0, 15.0, 4.0];
+    let v2f: [f64; 3] = [10.0, 15.0, 4.0];
 
     let lua = Lua::new();
     lua.context(|ctx| {
         let validate_arr_int = |tbl: Table| {
-            valid_int(tbl.get(1),10);
-            valid_int(tbl.get(2),15);
-            valid_int(tbl.get(3),4);
+            valid_int(tbl.get(1), 10);
+            valid_int(tbl.get(2), 15);
+            valid_int(tbl.get(3), 4);
         };
         valid_table(v1.to_lua(ctx), validate_arr_int);
         valid_table(v2.to_lua(ctx), validate_arr_int);
@@ -135,23 +130,24 @@ fn test_conversion_int_array_table() {
         valid_table(v12.to_lua(ctx), validate_arr_int);
 
         let validate_arr_float = |tbl: Table| {
-            validate_float(tbl.get(1),10.0);
-            validate_float(tbl.get(2),15.0);
-            validate_float(tbl.get(3),4.0);
+            valid_float(tbl.get(1), 10.0);
+            valid_float(tbl.get(2), 15.0);
+            valid_float(tbl.get(3), 4.0);
         };
         valid_table(v1f.to_lua(ctx), validate_arr_float);
         valid_table(v2f.to_lua(ctx), validate_arr_float);
     });
 }
 
-
 #[test]
 fn test_conversion_string() {
     Lua::new().context(|ctx| {
-        valid_string("hello world".to_lua(ctx), ctx.create_string("hello world").unwrap());
+        valid_string(
+            "hello world".to_lua(ctx),
+            ctx.create_string("hello world").unwrap(),
+        );
     });
 }
-
 
 #[test]
 fn test_conversion_boolean() {
@@ -159,4 +155,3 @@ fn test_conversion_boolean() {
         valid_boolean(true.to_lua(ctx), true);
     });
 }
-

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -9,6 +9,17 @@ fn valid_float(verify: Result<Value>, expected: f64) {
     };
 }
 
+#[cfg(rlua_lua51)]
+fn valid_int(verify: Result<Value>, expected: Integer) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "number");
+    match verify_unwrap {
+        Value::Number(value) => assert_eq!(value as Integer, expected),
+        _ => panic!("unexpected type"),
+    };
+}
+
+#[cfg(not(rlua_lua51))]
 fn valid_int(verify: Result<Value>, expected: Integer) {
     let verify_unwrap = verify.unwrap();
     assert_eq!(verify_unwrap.type_name(), "integer");

--- a/tests/conversion.rs
+++ b/tests/conversion.rs
@@ -1,0 +1,162 @@
+use rlua::{Lua, ToLua, Value, Result, Table, Error, String};
+
+fn validate_float(verify: Result<Value>, expected: f64) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "number");
+    match verify_unwrap {
+        Value::Number(value) => assert_eq!(value, expected),
+        _ => assert!(false, "unexpected type"),
+    };
+}
+
+fn valid_int(verify: Result<Value>, expected: i64) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "integer");
+    match verify_unwrap {
+        Value::Integer(value) => assert_eq!(value, expected),
+        _ => assert!(false, "unexpected type"),
+    };
+}
+
+fn valid_table(verify: Result<Value>, handler: fn(tbl: Table)) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "table");
+    match  verify_unwrap {
+        Value::Table(value) => handler(value),
+        _ =>  assert!(false, "unexpected type"),
+    };
+}
+
+fn valid_string(verify: Result<Value>, val: String) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "string");
+    match  verify_unwrap {
+        Value::String(value) => assert_eq!(value, val),
+        _ =>  assert!(false, "unexpected type"),
+    };
+}
+
+fn valid_boolean(verify: Result<Value>, val: bool) {
+    let verify_unwrap = verify.unwrap();
+    assert_eq!(verify_unwrap.type_name(), "boolean");
+    match  verify_unwrap {
+        Value::Boolean(value) => assert_eq!(value, val),
+        _ =>  assert!(false, "unexpected type"),
+    };
+}
+
+
+#[test]
+fn test_conversion_int_primitives() {
+    let lua = Lua::new();
+
+    let v :i8 = 10;
+    let v2 :u8 = 10;
+    let v3 :i16 = 10;
+    let v4 :u16 = 10;
+    let v5 :i32 = 10;
+    let v6 :u32 = 10;
+    let v7 :i64 = 10;
+    let v8 :u64 = 10;
+    let v9 :i128 = 10;
+    let v10 :u128 = 10;
+    let v11 :isize = 10;
+    let v12 :usize = 10;
+
+    lua.context(|ctx| {
+        valid_int(v.to_lua(ctx), 10);
+        valid_int(v2.to_lua(ctx), 10);
+        valid_int(v3.to_lua(ctx), 10);
+        valid_int(v4.to_lua(ctx), 10);
+        valid_int(v5.to_lua(ctx), 10);
+        valid_int(v6.to_lua(ctx), 10);
+        valid_int(v7.to_lua(ctx), 10);
+        valid_int(v8.to_lua(ctx), 10);
+        valid_int(v9.to_lua(ctx), 10);
+        valid_int(v10.to_lua(ctx), 10);
+        valid_int(v11.to_lua(ctx), 10);
+        valid_int(v12.to_lua(ctx), 10);
+    });
+}
+
+
+
+#[test]
+fn test_conversion_float_primatives() {
+    let lua = Lua::new();
+
+    let v :f32 = 10.0;
+    let v2 :f64 = 10.0;
+
+    lua.context(|ctx| {
+        validate_float(v.to_lua(ctx), 10.0);
+        validate_float(v2.to_lua(ctx), 10.0);
+    });
+}
+
+
+#[test]
+fn test_conversion_int_array_table() {
+
+    let v1 : [u32; 3] = [10,15,4];
+    let v2 : [u8; 3] = [10,15,4];
+    let v3 : [i16; 3] = [10,15,4];
+    let v4 : [u16; 3] = [10,15,4];
+    let v5 : [i32; 3] = [10,15,4];
+    let v6 : [u32; 3] = [10,15,4];
+    let v7 : [i64; 3] = [10,15,4];
+    let v8 : [u64; 3] = [10,15,4];
+    let v9 : [i128; 3] = [10,15,4];
+    let v10 : [u128; 3] = [10,15,4];
+    let v11 : [isize; 3] = [10,15,4];
+    let v12 : [usize; 3] = [10,15,4];
+
+    let v1f : [f32; 3] = [10.0,15.0,4.0];
+    let v2f : [f64; 3] = [10.0,15.0,4.0];
+
+    let lua = Lua::new();
+    lua.context(|ctx| {
+        let validate_arr_int = |tbl: Table| {
+            valid_int(tbl.get(1),10);
+            valid_int(tbl.get(2),15);
+            valid_int(tbl.get(3),4);
+        };
+        valid_table(v1.to_lua(ctx), validate_arr_int);
+        valid_table(v2.to_lua(ctx), validate_arr_int);
+        valid_table(v3.to_lua(ctx), validate_arr_int);
+        valid_table(v4.to_lua(ctx), validate_arr_int);
+        valid_table(v5.to_lua(ctx), validate_arr_int);
+        valid_table(v6.to_lua(ctx), validate_arr_int);
+        valid_table(v7.to_lua(ctx), validate_arr_int);
+        valid_table(v8.to_lua(ctx), validate_arr_int);
+        valid_table(v9.to_lua(ctx), validate_arr_int);
+        valid_table(v10.to_lua(ctx), validate_arr_int);
+        valid_table(v11.to_lua(ctx), validate_arr_int);
+        valid_table(v12.to_lua(ctx), validate_arr_int);
+
+        let validate_arr_float = |tbl: Table| {
+            validate_float(tbl.get(1),10.0);
+            validate_float(tbl.get(2),15.0);
+            validate_float(tbl.get(3),4.0);
+        };
+        valid_table(v1f.to_lua(ctx), validate_arr_float);
+        valid_table(v2f.to_lua(ctx), validate_arr_float);
+    });
+}
+
+
+#[test]
+fn test_conversion_string() {
+    Lua::new().context(|ctx| {
+        valid_string("hello world".to_lua(ctx), ctx.create_string("hello world").unwrap());
+    });
+}
+
+
+#[test]
+fn test_conversion_boolean() {
+    Lua::new().context(|ctx| {
+        valid_boolean(true.to_lua(ctx), true);
+    });
+}
+

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -129,7 +129,7 @@ fn limit_execution_instructions() {
     lua.context(|lua| {
         #[cfg(rlua_lua51)]
         lua.globals().set("x", Value::Number(0.0)).unwrap();
-        #[cfg(any(rlua_lua53,rlua_lua54))]
+        #[cfg(any(rlua_lua53, rlua_lua54))]
         lua.globals().set("x", Value::Integer(0)).unwrap();
         let _ = lua
             .load(

--- a/tests/hooks.rs
+++ b/tests/hooks.rs
@@ -127,6 +127,9 @@ fn limit_execution_instructions() {
     );
 
     lua.context(|lua| {
+        #[cfg(rlua_lua51)]
+        lua.globals().set("x", Value::Number(0.0)).unwrap();
+        #[cfg(any(rlua_lua53,rlua_lua54))]
         lua.globals().set("x", Value::Integer(0)).unwrap();
         let _ = lua
             .load(


### PR DESCRIPTION
This is the same as #230 with a fix for Lua 5.1 (I removed Value::Integer as it doesn't exist in Lua < 5.3).