### PR TITLE
Allow disabling the pcall/xpcall wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::context::{Chunk, Context};
 pub use crate::error::{Error, ExternalError, ExternalResult, Result};
 pub use crate::function::Function;
 pub use crate::hook::{Debug, DebugNames, DebugSource, DebugStack, HookTriggers};
-pub use crate::lua::{Lua, StdLib};
+pub use crate::lua::{Lua, StdLib, InitFlags};
 pub use crate::multi::Variadic;
 pub use crate::scope::Scope;
 pub use crate::string::String;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::context::{Chunk, Context};
 pub use crate::error::{Error, ExternalError, ExternalResult, Result};
 pub use crate::function::Function;
 pub use crate::hook::{Debug, DebugNames, DebugSource, DebugStack, HookTriggers};
-pub use crate::lua::{Lua, StdLib, InitFlags};
+pub use crate::lua::{InitFlags, Lua, StdLib};
 pub use crate::multi::Variadic;
 pub use crate::scope::Scope;
 pub use crate::string::String;

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -543,7 +543,7 @@ unsafe fn create_lua(lua_mod_to_load: StdLib, init_flags: InitFlags) -> Lua {
         protect_lua_closure(state, 0, 0, |state| {
             load_from_std_lib(state, lua_mod_to_load);
 
-            init_error_registry(state);
+            init_error_registry(state, init_flags.contains(InitFlags::PCALL_WRAPPERS));
 
             // Create the function metatable
 

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -146,6 +146,22 @@ impl Lua {
         create_lua(lua_mod, InitFlags::DEFAULT)
     }
 
+    /// Creates a new Lua state with a subset of the standard libraries and
+    /// modified initialization.
+    ///
+    /// Use the [`StdLib`] flags to specifiy the libraries you want to load.
+    /// Use the [`InitFlags`] to specify non-default Lua configuration.
+    ///
+    /// `unsafe_new_with_flags(mods, InitFlags::DEFAULT)` is equivalent to
+    /// `unsafe_new_with(mods)`.
+    ///
+    /// This function is unsafe because it can be used to load the `debug` library which can be used
+    /// to break the safety guarantees provided by rlua, or to disable some of the safety features
+    /// which rlua provides by default.
+    pub unsafe fn unsafe_new_with_flags(lua_mod: StdLib, init_flags: InitFlags) -> Lua {
+        create_lua(lua_mod, init_flags)
+    }
+
     /// Loads the specified set of safe standard libraries into an existing Lua state.
     ///
     /// Use the [`StdLib`] flags to specifiy the libraries you want to load.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1213,7 +1213,13 @@ unsafe fn get_panic_metatable(state: *mut ffi::lua_State) -> bool {
         state,
         &PANIC_METATABLE_REGISTRY_KEY as *const u8 as *mut c_void,
     );
+    #[cfg(any(rlua_lua53, rlua_lua54))]
     let mt_type = ffi::lua_rawget(state, ffi::LUA_REGISTRYINDEX);
+    #[cfg(rlua_lua51)]
+    let mt_type = {
+        ffi::lua_rawget(state, ffi::LUA_REGISTRYINDEX);
+        ffi::lua_type(state, -1)
+    };
     if mt_type == ffi::LUA_TTABLE {
         true
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -823,9 +823,16 @@ where
         Err(p) => {
             ffi::lua_settop(state, 1);
             ptr::write(ud as *mut WrappedPanic, WrappedPanic(Some(p)));
-            get_panic_metatable(state);
-            ffi::lua_setmetatable(state, -2);
-            ffi::lua_error(state)
+            if get_panic_metatable(state) {
+                ffi::lua_setmetatable(state, -2);
+                ffi::lua_error(state)
+            } else {
+                // The pcall/xpcall wrappers which allow sending a panic
+                // safeul through Lua have not been enabled.
+                // We can't allow a panic to cross the C/Rust boundary, so the
+                // only choice is to abort.
+                std::process::abort()
+            }
         }
     }
 }
@@ -983,7 +990,7 @@ pub unsafe fn get_wrapped_error(state: *mut ffi::lua_State, index: c_int) -> *co
 }
 
 // Initialize the error, panic, and destructed userdata metatables.
-pub unsafe fn init_error_registry(state: *mut ffi::lua_State) {
+pub unsafe fn init_error_registry(state: *mut ffi::lua_State, wrap_panics: bool) {
     assert_stack(state, 8);
 
     // Create error metatable
@@ -1042,22 +1049,23 @@ pub unsafe fn init_error_registry(state: *mut ffi::lua_State) {
     ffi::lua_rawset(state, ffi::LUA_REGISTRYINDEX);
 
     // Create panic metatable
+    if wrap_panics {
+        ffi::lua_pushlightuserdata(
+            state,
+            &PANIC_METATABLE_REGISTRY_KEY as *const u8 as *mut c_void,
+        );
+        ffi::lua_newtable(state);
 
-    ffi::lua_pushlightuserdata(
-        state,
-        &PANIC_METATABLE_REGISTRY_KEY as *const u8 as *mut c_void,
-    );
-    ffi::lua_newtable(state);
+        ffi::lua_pushstring(state, cstr!("__gc"));
+        ffi::lua_pushcfunction(state, userdata_destructor::<WrappedPanic>);
+        ffi::lua_rawset(state, -3);
 
-    ffi::lua_pushstring(state, cstr!("__gc"));
-    ffi::lua_pushcfunction(state, userdata_destructor::<WrappedPanic>);
-    ffi::lua_rawset(state, -3);
+        ffi::lua_pushstring(state, cstr!("__metatable"));
+        ffi::lua_pushboolean(state, 0);
+        ffi::lua_rawset(state, -3);
 
-    ffi::lua_pushstring(state, cstr!("__metatable"));
-    ffi::lua_pushboolean(state, 0);
-    ffi::lua_rawset(state, -3);
-
-    ffi::lua_rawset(state, ffi::LUA_REGISTRYINDEX);
+        ffi::lua_rawset(state, ffi::LUA_REGISTRYINDEX);
+    }
 
     // Create destructed userdata metatable
 
@@ -1176,10 +1184,13 @@ unsafe fn is_wrapped_panic(state: *mut ffi::lua_State, index: c_int) -> bool {
         return false;
     }
 
-    get_panic_metatable(state);
-    let res = ffi::lua_rawequal(state, -1, -2) != 0;
-    ffi::lua_pop(state, 2);
-    res
+    if get_panic_metatable(state) {
+        let res = ffi::lua_rawequal(state, -1, -2) != 0;
+        ffi::lua_pop(state, 2);
+        res
+    } else {
+        false
+    }
 }
 
 unsafe fn get_error_metatable(state: *mut ffi::lua_State) {
@@ -1190,12 +1201,26 @@ unsafe fn get_error_metatable(state: *mut ffi::lua_State) {
     ffi::lua_rawget(state, ffi::LUA_REGISTRYINDEX);
 }
 
-unsafe fn get_panic_metatable(state: *mut ffi::lua_State) {
+/// Get the special panic error metatable from the registry.
+///
+/// This may fail if the Lua state was created without the pcall
+/// wrappers.
+///
+/// Returns true if the metatable was pushed to the stack, or false
+/// otherwise (nothing will have been pushed).
+unsafe fn get_panic_metatable(state: *mut ffi::lua_State) -> bool {
     ffi::lua_pushlightuserdata(
         state,
         &PANIC_METATABLE_REGISTRY_KEY as *const u8 as *mut c_void,
     );
-    ffi::lua_rawget(state, ffi::LUA_REGISTRYINDEX);
+    let mt_type = ffi::lua_rawget(state, ffi::LUA_REGISTRYINDEX);
+    if mt_type == ffi::LUA_TTABLE {
+        true
+    } else {
+        panic!("get_panic_metatable failed: type {}", mt_type);
+        ffi::lua_pop(state, 1);
+        false
+    }
 }
 
 unsafe fn get_destructed_userdata_metatable(state: *mut ffi::lua_State) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1217,7 +1217,6 @@ unsafe fn get_panic_metatable(state: *mut ffi::lua_State) -> bool {
     if mt_type == ffi::LUA_TTABLE {
         true
     } else {
-        panic!("get_panic_metatable failed: type {}", mt_type);
         ffi::lua_pop(state, 1);
         false
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::{error, f32, f64, fmt};
 
 use rlua::{
-    Error, ExternalError, Function, Lua, Nil, Result, StdLib, String, Table, UserData, Value,
+    Error, ExternalError, Function, /* InitFlags, */ Lua, Nil, Result, StdLib, String, Table, UserData, Value,
     Variadic,
 };
 
@@ -255,7 +255,7 @@ fn test_error() {
 
         match return_error.call::<_, Value>(()) {
             Ok(Value::Error(_)) => {}
-            _ => panic!("Value::Error not returned"),
+            e => panic!("Value::Error not returned: got {:?}", e),
         }
 
         assert!(return_string_error.call::<_, Error>(()).is_ok());
@@ -339,6 +339,72 @@ fn test_error() {
         Err(p) => assert!(*p.downcast::<&str>().unwrap() == "test_panic"),
     };
 }
+
+// Test that skipping the pcall/xpcall wrappers works.
+// TODO: The only way to test that the behaviour is correct is to
+// cause it to abort().
+/*
+#[test]
+fn test_error_nopcall_wrap() {
+    match catch_unwind(|| -> Result<()> {
+        unsafe {
+            Lua::unsafe_new_with_flags(StdLib::ALL, InitFlags::DEFAULT - InitFlags::PCALL_WRAPPERS).context(|lua| {
+                let globals = lua.globals();
+
+                lua.load(
+                    r#"
+                        function rust_panic()
+                            pcall(function () rust_panic_function() end)
+                        end
+                    "#,
+                )
+                .exec()?;
+                let rust_panic_function = lua
+                    .create_function(|_, ()| -> Result<()> { panic!("test_panic") })
+                    .unwrap();
+                globals.set("rust_panic_function", rust_panic_function)?;
+
+                let rust_panic = globals.get::<_, Function>("rust_panic")?;
+
+                rust_panic.call::<_, ()>(())
+            })
+        }
+    }) {
+        Ok(Ok(_)) => panic!("no panic was detected, pcall caught it!"),
+        Ok(Err(e)) => panic!("error during panic test {:?}", e),
+        Err(p) => assert!(*p.downcast::<&str>().unwrap() == "test_panic"),
+    };
+
+    match catch_unwind(|| -> Result<()> {
+        unsafe {
+            Lua::unsafe_new_with_flags(StdLib::ALL, InitFlags::DEFAULT - InitFlags::PCALL_WRAPPERS).context(|lua| {
+                let globals = lua.globals();
+
+                lua.load(
+                    r#"
+                        function rust_panic()
+                            xpcall(function() rust_panic_function() end, function() end)
+                        end
+                    "#,
+                )
+                .exec()?;
+                let rust_panic_function = lua
+                    .create_function(|_, ()| -> Result<()> { panic!("test_panic") })
+                    .unwrap();
+                globals.set("rust_panic_function", rust_panic_function)?;
+
+                let rust_panic = globals.get::<_, Function>("rust_panic")?;
+
+                rust_panic.call::<_, ()>(())
+            })
+        }
+    }) {
+        Ok(Ok(_)) => panic!("no panic was detected, xpcall caught it!"),
+        Ok(Err(e)) => panic!("error during panic test {:?}", e),
+        Err(p) => assert!(*p.downcast::<&str>().unwrap() == "test_panic"),
+    };
+}
+*/
 
 #[test]
 fn test_result_conversions() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::{error, f32, f64, fmt};
 
 use rlua::{
-    Error, ExternalError, Function, /* InitFlags, */ Lua, Nil, Result, StdLib, String, Table, UserData, Value,
-    Variadic,
+    Error, ExternalError, Function, /* InitFlags, */ Lua, Nil, Result, StdLib, String, Table,
+    UserData, Value, Variadic,
 };
 
 #[test]


### PR DESCRIPTION
Fixes issue #190 
When the pcall/xpcall wrappers are not installed, a panic which reaches the Lua boundary will turn into an abort, as unwinding into C code is UB.