### PR TITLE
Optional oslib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.19.3]
+- Add new features `lua-no-oslib` to not compile in the `os` lib to the
+  Lua library.  Useful for targets (e.g. iOS) where the `os` lib is unavailable.
+
 ## [0.19.2]
 - Fix issue #253 (userdata types with alignment > 8 bytes could cause crashes)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ system-lua53=["rlua-lua53-sys", "rlua-lua53-sys/lua53-pkg-config"]
 system-lua51=["rlua-lua51-sys", "rlua-lua51-sys/lua51-pkg-config"]
 
 # Remove Lua's os lib
-lua-no-oslib=["rlua-lua54-sys/lua-no-oslib"]
-lua-no-oslib=["rlua-lua53-sys/lua-no-oslib"]
-lua-no-oslib=["rlua-lua51-sys/lua-no-oslib"]
+lua-no-oslib=["rlua-lua54-sys/lua-no-oslib","rlua-lua53-sys/lua-no-oslib","rlua-lua51-sys/lua-no-oslib"]
 
 # Enabled functions from the math module that have been deprecated
 lua-compat-mathlib = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ system-lua54=["rlua-lua54-sys", "rlua-lua54-sys/lua54-pkg-config"]
 system-lua53=["rlua-lua53-sys", "rlua-lua53-sys/lua53-pkg-config"]
 system-lua51=["rlua-lua51-sys", "rlua-lua51-sys/lua51-pkg-config"]
 
+# Remove Lua's os lib
+lua-no-oslib=["rlua-lua54-sys/lua-no-oslib"]
 # Enabled functions from the math module that have been deprecated
 lua-compat-mathlib = []
 
@@ -32,7 +34,7 @@ libc = { version = "0.2" }
 num-traits = { version = "0.2.14" }
 bitflags = { version = "1.0.4" }
 bstr = {version = "0.2", features = ["std"], default_features = false }
-rlua-lua54-sys = { version = "0.1.2", optional = true }
+rlua-lua54-sys = { optional = true, path = "crates/rlua-lua54-sys" }
 rlua-lua53-sys = { version = "0.1.2", optional = true }
 rlua-lua51-sys = { version = "0.1.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ libc = { version = "0.2" }
 num-traits = { version = "0.2.14" }
 bitflags = { version = "1.0.4" }
 bstr = {version = "0.2", features = ["std"], default_features = false }
-rlua-lua54-sys = { optional = true, path = "crates/rlua-lua54-sys" }
+rlua-lua54-sys = { version = "0.1.3", optional = true }
 rlua-lua53-sys = { version = "0.1.2", optional = true }
 rlua-lua51-sys = { version = "0.1.2", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["kyren <kerriganw@gmail.com>"]
 edition = "2018"
 description = "High level bindings to Lua 5.x"
@@ -25,6 +25,9 @@ system-lua51=["rlua-lua51-sys", "rlua-lua51-sys/lua51-pkg-config"]
 
 # Remove Lua's os lib
 lua-no-oslib=["rlua-lua54-sys/lua-no-oslib"]
+lua-no-oslib=["rlua-lua53-sys/lua-no-oslib"]
+lua-no-oslib=["rlua-lua51-sys/lua-no-oslib"]
+
 # Enabled functions from the math module that have been deprecated
 lua-compat-mathlib = []
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ implementations (such as Luajit) which share PUC-Rio Lua's C API, but it is
 expected that they can be made to work with little if any change to rlua, and
 support would be welcome.
 
+### Other Lua features
+
+Some other features affect how Lua is built (for the builtin versions):
+
+| Cargo feature | Effect |
+| ------------- | ------ |
+| lua-no-oslib | Don't compile the Lua `os` library at all (builtin Lua libraries). |
+
 ## Safety and Panics
 
 The goal of this library is complete safety by default: it should not be

--- a/crates/rlua-lua51-sys/Cargo.toml
+++ b/crates/rlua-lua51-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua-lua51-sys"
-version = "0.1.2"
+version = "0.1.3"
 keywords = ["bindings", "lua"]
 categories = ["external-ffi-bindings"]
 description = "Bindings to lua's C API"

--- a/crates/rlua-lua51-sys/Cargo.toml
+++ b/crates/rlua-lua51-sys/Cargo.toml
@@ -22,3 +22,4 @@ pkg-config = "0.3.24"
 default = []
 lua51-pkg-config = []
 static = []
+lua-no-oslib = []

--- a/crates/rlua-lua51-sys/build.rs
+++ b/crates/rlua-lua51-sys/build.rs
@@ -40,7 +40,6 @@ fn main() {
             .file(lua_dir.join("ldump.c"))
             .file(lua_dir.join("lfunc.c"))
             .file(lua_dir.join("lgc.c"))
-            .file(lua_dir.join("linit.c"))
             .file(lua_dir.join("liolib.c"))
             .file(lua_dir.join("llex.c"))
             .file(lua_dir.join("lmathlib.c"))
@@ -49,7 +48,6 @@ fn main() {
             .file(lua_dir.join("loadlib.c"))
             .file(lua_dir.join("lobject.c"))
             .file(lua_dir.join("lopcodes.c"))
-            .file(lua_dir.join("loslib.c"))
             .file(lua_dir.join("lparser.c"))
             .file(lua_dir.join("lstate.c"))
             .file(lua_dir.join("lstring.c"))
@@ -60,6 +58,12 @@ fn main() {
             .file(lua_dir.join("lundump.c"))
             .file(lua_dir.join("lvm.c"))
             .file(lua_dir.join("lzio.c"));
+
+        if !cfg!(feature = "lua-no-oslib") {
+            cc_config_build = cc_config_build
+                .file(lua_dir.join("loslib.c"))
+                .file(lua_dir.join("linit.c"));
+        }
 
         cc_config_build
             .out_dir(dst.join("lib"))

--- a/crates/rlua-lua53-sys/Cargo.toml
+++ b/crates/rlua-lua53-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua-lua53-sys"
-version = "0.1.2"
+version = "0.1.3"
 keywords = ["bindings", "lua"]
 categories = ["external-ffi-bindings"]
 description = "Bindings to lua's C API"

--- a/crates/rlua-lua53-sys/Cargo.toml
+++ b/crates/rlua-lua53-sys/Cargo.toml
@@ -22,3 +22,4 @@ pkg-config = "0.3.24"
 default = []
 lua53-pkg-config = []
 static = []
+lua-no-oslib = []

--- a/crates/rlua-lua53-sys/build.rs
+++ b/crates/rlua-lua53-sys/build.rs
@@ -44,7 +44,6 @@ fn main() {
             .file(lua_dir.join("ldump.c"))
             .file(lua_dir.join("lfunc.c"))
             .file(lua_dir.join("lgc.c"))
-            .file(lua_dir.join("linit.c"))
             .file(lua_dir.join("liolib.c"))
             .file(lua_dir.join("llex.c"))
             .file(lua_dir.join("lmathlib.c"))
@@ -52,7 +51,6 @@ fn main() {
             .file(lua_dir.join("loadlib.c"))
             .file(lua_dir.join("lobject.c"))
             .file(lua_dir.join("lopcodes.c"))
-            .file(lua_dir.join("loslib.c"))
             .file(lua_dir.join("lparser.c"))
             .file(lua_dir.join("lstate.c"))
             .file(lua_dir.join("lstring.c"))
@@ -64,6 +62,12 @@ fn main() {
             .file(lua_dir.join("lutf8lib.c"))
             .file(lua_dir.join("lvm.c"))
             .file(lua_dir.join("lzio.c"));
+
+        if !cfg!(feature = "lua-no-oslib") {
+            cc_config_build = cc_config_build
+                .file(lua_dir.join("loslib.c"))
+                .file(lua_dir.join("linit.c"));
+        }
 
         cc_config_build
             .out_dir(dst.join("lib"))

--- a/crates/rlua-lua54-sys/Cargo.toml
+++ b/crates/rlua-lua54-sys/Cargo.toml
@@ -22,3 +22,4 @@ pkg-config = "0.3.24"
 default = []
 lua54-pkg-config = []
 static = []
+lua-no-oslib = []

--- a/crates/rlua-lua54-sys/Cargo.toml
+++ b/crates/rlua-lua54-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua-lua54-sys"
-version = "0.1.2"
+version = "0.1.3"
 keywords = ["bindings", "lua"]
 categories = ["external-ffi-bindings"]
 description = "Bindings to lua's C API"

--- a/crates/rlua-lua54-sys/build.rs
+++ b/crates/rlua-lua54-sys/build.rs
@@ -42,7 +42,6 @@ fn main() {
             .file(lua_dir.join("ldump.c"))
             .file(lua_dir.join("lfunc.c"))
             .file(lua_dir.join("lgc.c"))
-            .file(lua_dir.join("linit.c"))
             .file(lua_dir.join("liolib.c"))
             .file(lua_dir.join("llex.c"))
             .file(lua_dir.join("lmathlib.c"))
@@ -51,7 +50,6 @@ fn main() {
             .file(lua_dir.join("loadlib.c"))
             .file(lua_dir.join("lobject.c"))
             .file(lua_dir.join("lopcodes.c"))
-            .file(lua_dir.join("loslib.c"))
             .file(lua_dir.join("lparser.c"))
             .file(lua_dir.join("lstate.c"))
             .file(lua_dir.join("lstring.c"))
@@ -63,6 +61,12 @@ fn main() {
             .file(lua_dir.join("lutf8lib.c"))
             .file(lua_dir.join("lvm.c"))
             .file(lua_dir.join("lzio.c"));
+
+        if !cfg!(feature = "lua-no-oslib") {
+            cc_config_build = cc_config_build
+                .file(lua_dir.join("loslib.c"))
+                .file(lua_dir.join("linit.c"));
+        }
 
         cc_config_build
             .out_dir(dst.join("lib"))

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -782,6 +782,7 @@ unsafe fn load_from_std_lib(state: *mut ffi::lua_State, lua_mod: StdLib) {
     if lua_mod.contains(StdLib::IO) {
         requiref(state, cstr!("io"), Some(ffi::luaopen_io), 1);
     }
+    #[cfg(feature = "lua-no-oslib")]
     if lua_mod.contains(StdLib::OS) {
         requiref(state, cstr!("os"), Some(ffi::luaopen_os), 1);
     }


### PR DESCRIPTION
Add a new feature `lua-no-oslib` to leave out the `os` lib from the Lua library entirely.

Should fix #255.