### PR TITLE
Fix no oslib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,38 @@ jobs:
             - target/debug/build
             - target/debug/deps
           key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+  build-no-oslib:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run:
+          name: Install libclang for bindgen
+          command: |
+            sudo apt-get update
+            sudo apt-get install libclang-dev clang
+      - run:
+          name: Version information
+          command: rustc --version; cargo --version; rustup --version
+      - run:
+          name: Calculate dependencies
+          command: cargo generate-lockfile
+      - restore_cache:
+          keys:
+            - cargo-cache-no-oslib-{{ arch }}-{{ checksum "Cargo.lock" }}
+      - run:
+          name: Build all targets
+          command: cargo build --features=lua-no-oslib --all --all-targets
+      - run:
+          name: Run all tests
+          command: cargo test --features=lua-no-oslib --all
+      - save_cache:
+          paths:
+            - /usr/local/cargo/registry
+            - target/debug/.fingerprint
+            - target/debug/build
+            - target/debug/deps
+          key: cargo-cache-no-oslib-{{ arch }}-{{ checksum "Cargo.lock" }}
   build-lua53:
     docker:
       - image: circleci/rust:latest
@@ -186,3 +218,4 @@ workflows:
       - "build-lua53"
       - "build-lua51"
       - "build-windows"
+      - "build-no-oslib"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.19.4]
+- Fix the `lua-no-oslib` feature introduced with a bug in 0.19.3.
+
 ## [0.19.3]
 - Add new features `lua-no-oslib` to not compile in the `os` lib to the
   Lua library.  Useful for targets (e.g. iOS) where the `os` lib is unavailable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlua"
-version = "0.19.3"
+version = "0.19.4"
 authors = ["kyren <kerriganw@gmail.com>"]
 edition = "2018"
 description = "High level bindings to Lua 5.x"

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -782,7 +782,7 @@ unsafe fn load_from_std_lib(state: *mut ffi::lua_State, lua_mod: StdLib) {
     if lua_mod.contains(StdLib::IO) {
         requiref(state, cstr!("io"), Some(ffi::luaopen_io), 1);
     }
-    #[cfg(feature = "lua-no-oslib")]
+    #[cfg(not(feature = "lua-no-oslib"))]
     if lua_mod.contains(StdLib::OS) {
         requiref(state, cstr!("os"), Some(ffi::luaopen_os), 1);
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1437,3 +1437,38 @@ fn context_thread_lua51() {
         thrd.resume::<_, ()>(thrd_cloned).unwrap();
     });
 }
+
+// Test the lua-no-oslib feature
+#[cfg(feature = "lua-no-oslib")]
+#[test]
+fn test_no_oslib() {
+    Lua::new().context(|lua_ctx| {
+        let f = lua_ctx
+            .load(
+                r#"
+                    assert(os == nil)
+                "#,
+            )
+            .into_function()
+            .unwrap();
+        f.call::<_, ()>(()).unwrap();
+    });
+}
+
+// Test the lua-no-oslib feature
+#[cfg(not(feature = "lua-no-oslib"))]
+#[test]
+fn test_with_oslib() {
+    Lua::new().context(|lua_ctx| {
+        let f = lua_ctx
+            .load(
+                r#"
+                    local x = os.time()
+                    assert(x > 0)
+                "#,
+            )
+            .into_function()
+            .unwrap();
+        f.call::<_, ()>(()).unwrap();
+    });
+}


### PR DESCRIPTION
The `lua-no-oslib` feature had a reversed config check.

Add tests and a new CI builder to check it works.