### PR TITLE
Add support for iOS to `rlua-lua54`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libc = { version = "0.2" }
 num-traits = { version = "0.2.14" }
 bitflags = { version = "1.0.4" }
 bstr = {version = "0.2", features = ["std"], default_features = false }
-rlua-lua54-sys = { path = "crates/rlua-lua54-sys", optional = true }
+rlua-lua54-sys = { version = "0.1.6", optional = true }
 rlua-lua53-sys = { version = "0.1.6", optional = true }
 rlua-lua51-sys = { version = "0.1.6", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libc = { version = "0.2" }
 num-traits = { version = "0.2.14" }
 bitflags = { version = "1.0.4" }
 bstr = {version = "0.2", features = ["std"], default_features = false }
-rlua-lua54-sys = { version = "0.1.6", optional = true }
+rlua-lua54-sys = { path = "crates/rlua-lua54-sys", optional = true }
 rlua-lua53-sys = { version = "0.1.6", optional = true }
 rlua-lua51-sys = { version = "0.1.6", optional = true }
 

--- a/crates/rlua-lua54-sys/build.rs
+++ b/crates/rlua-lua54-sys/build.rs
@@ -22,6 +22,8 @@ fn main() {
             cc_config.define("LUA_USE_LINUX", None);
         } else if target_os == Ok("macos".to_string()) {
             cc_config.define("LUA_USE_MACOSX", None);
+        } else if target_os == Ok("ios".to_string()) {
+            cc_config.define("LUA_USE_IOS", None);
         } else if target_family == Ok("unix".to_string()) {
             cc_config.define("LUA_USE_POSIX", None);
         } else if target_family == Ok("windows".to_string()) {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -102,7 +102,7 @@ impl Drop for Lua {
             );
             *rlua_expect!((*extra).registry_unref_list.lock(), "unref list poisoned") = None;
             ffi::lua_close(self.main_state);
-            Box::from_raw(extra);
+            let _ = Box::from_raw(extra);
         }
     }
 }


### PR DESCRIPTION
Lua 5.4 supports iOS by defining a dummy `system` function, but `rlua` doesn't support building for iOS because of a missing preprocessor directive. 
This PR doesn't modify any original lua source code, it only adds a compiler flag based on the target platform.

Additionally, I fixed a warning for an unused return value :-)

Probably no need to update `Cargo.toml` to use a relative path after this version is released to crates.io...