### PR TITLE
Fix #281: Crash on empty source

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-default:
     docker:
-      - image: cimg/rust:1.69.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:
@@ -50,7 +50,7 @@ jobs:
           key: cargo-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
   build-no-oslib:
     docker:
-      - image: cimg/rust:1.69.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:
@@ -82,7 +82,7 @@ jobs:
           key: cargo-cache-no-oslib-{{ arch }}-{{ checksum "Cargo.lock" }}
   build-lua53:
     docker:
-      - image: cimg/rust:1.69.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:
@@ -126,7 +126,7 @@ jobs:
           key: cargo-cache-lua53-{{ arch }}-{{ checksum "Cargo.lock" }}
   build-lua51:
     docker:
-      - image: cimg/rust:1.69.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:
@@ -176,7 +176,7 @@ jobs:
           key: cargo-cache-lua51-{{ arch }}-{{ checksum "Cargo.lock" }}
   build-luajit:
     docker:
-      - image: cimg/rust:1.69.0
+      - image: cimg/rust:1.70.0
     steps:
       - checkout
       - run:

--- a/examples/custom_lua_path.rs
+++ b/examples/custom_lua_path.rs
@@ -4,7 +4,9 @@ fn main() -> Result<()> {
     let lua = Lua::new();
     lua.context(|lua_ctx| {
         // add `some_directory` to the package path
-        lua_ctx.load("package.path = package.path .. ';./examples/some_directory/?.lua'").exec()?;
+        lua_ctx
+            .load("package.path = package.path .. ';./examples/some_directory/?.lua'")
+            .exec()?;
 
         // require a module located in the newly added directory
         lua_ctx.load("require'new_module'").exec()?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -21,6 +21,13 @@ fn test_load() {
 }
 
 #[test]
+fn test_load_empty() {
+    Lua::new().context(|lua| {
+        assert!(lua.load(b"").exec().is_ok());
+    });
+}
+
+#[test]
 fn test_debug() {
     let lua = unsafe { Lua::new_with_debug() };
     lua.context(|lua| {


### PR DESCRIPTION
The Lua 5.1 loadbufferx wrapper was not pushing an error onto the stack as expected when validating the text/binary mode, leading to an assertion when that happened - this would have affected empty sources or source/compiled modules when that mode was not enabled.