### PR TITLE
Implement nested composition of FromLuaMulti

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -179,7 +179,8 @@ impl<'lua> Context<'lua> {
         F: 'static + Send + Fn(Context<'lua>, A) -> Result<R>,
     {
         self.create_callback(Box::new(move |lua, args| {
-            func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+            let mut consumed = 0;
+            func(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
         }))
     }
 
@@ -365,8 +366,12 @@ impl<'lua> Context<'lua> {
     }
 
     /// Converts a `MultiValue` instance into a value that implements `FromLuaMulti`.
-    pub fn unpack_multi<T: FromLuaMulti<'lua>>(self, value: MultiValue<'lua>) -> Result<T> {
-        T::from_lua_multi(value, self)
+    pub fn unpack_multi<T: FromLuaMulti<'lua>>(
+        self,
+        value: MultiValue<'lua>,
+        consumed: &mut usize,
+    ) -> Result<T> {
+        T::from_lua_multi(value, self, consumed)
     }
 
     /// Set a value in the Lua registry based on a string name.
@@ -1131,7 +1136,9 @@ impl<'lua, T: 'static + UserData> StaticUserDataMethods<'lua, T> {
             if let Some(front) = args.pop_front() {
                 let userdata = AnyUserData::from_lua(front, lua)?;
                 let userdata = userdata.borrow::<T>()?;
-                method(lua, &userdata, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                method(lua, &userdata, A::from_lua_multi(args, lua, &mut consumed)?)?
+                    .to_lua_multi(lua)
             } else {
                 Err(Error::FromLuaConversionError {
                     from: "missing argument",
@@ -1156,7 +1163,13 @@ impl<'lua, T: 'static + UserData> StaticUserDataMethods<'lua, T> {
                 let mut method = method
                     .try_borrow_mut()
                     .map_err(|_| Error::RecursiveMutCallback)?;
-                (&mut *method)(lua, &mut userdata, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                (&mut *method)(
+                    lua,
+                    &mut userdata,
+                    A::from_lua_multi(args, lua, &mut consumed)?,
+                )?
+                .to_lua_multi(lua)
             } else {
                 Err(Error::FromLuaConversionError {
                     from: "missing argument",
@@ -1173,7 +1186,10 @@ impl<'lua, T: 'static + UserData> StaticUserDataMethods<'lua, T> {
         R: ToLuaMulti<'lua>,
         F: 'static + Send + Fn(Context<'lua>, A) -> Result<R>,
     {
-        Box::new(move |lua, args| function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua))
+        Box::new(move |lua, args| {
+            let mut consumed = 0;
+            function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
+        })
     }
 
     fn box_function_mut<A, R, F>(function: F) -> Callback<'lua, 'static>
@@ -1187,7 +1203,8 @@ impl<'lua, T: 'static + UserData> StaticUserDataMethods<'lua, T> {
             let function = &mut *function
                 .try_borrow_mut()
                 .map_err(|_| Error::RecursiveMutCallback)?;
-            function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+            let mut consumed = 0;
+            function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
         })
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -88,7 +88,8 @@ impl<'lua> Function<'lua> {
             ffi::lua_pop(lua.state, 1);
             results
         };
-        R::from_lua_multi(results, lua)
+        let mut consumed = 0;
+        R::from_lua_multi(results, lua, &mut consumed)
     }
 
     /// Returns a function that, when called, calls `self`, passing `args` as the first set of

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -64,7 +64,8 @@ impl<'lua, 'scope> Scope<'lua, 'scope> {
         // scope, and owned inside the callback itself.
         unsafe {
             self.create_callback(Box::new(move |lua, args| {
-                func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                func(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             }))
         }
     }
@@ -381,7 +382,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.methods.push((
             name.as_ref().to_vec(),
             NonStaticMethod::Method(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                method(lua, ud, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -396,7 +398,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.methods.push((
             name.as_ref().to_vec(),
             NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                method(lua, ud, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -411,7 +414,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.methods.push((
             name.as_ref().to_vec(),
             NonStaticMethod::Function(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -426,7 +430,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.methods.push((
             name.as_ref().to_vec(),
             NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -440,7 +445,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.meta_methods.push((
             meta,
             NonStaticMethod::Method(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                method(lua, ud, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -454,7 +460,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.meta_methods.push((
             meta,
             NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                method(lua, ud, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -468,7 +475,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.meta_methods.push((
             meta,
             NonStaticMethod::Function(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }
@@ -482,7 +490,8 @@ impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'l
         self.meta_methods.push((
             meta,
             NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+                let mut consumed = 0;
+                function(lua, A::from_lua_multi(args, lua, &mut consumed)?)?.to_lua_multi(lua)
             })),
         ));
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -119,7 +119,8 @@ impl<'lua> Thread<'lua> {
             }
             results
         };
-        R::from_lua_multi(results, lua)
+        let mut consumed = 0;
+        R::from_lua_multi(results, lua, &mut consumed)
     }
 
     /// Gets the status of the thread.

--- a/src/value.rs
+++ b/src/value.rs
@@ -142,8 +142,16 @@ impl<'lua> MultiValue<'lua> {
         self.0.push(value);
     }
 
+    pub(crate) fn push_front_many(&mut self, values: Self) {
+        self.0.extend(values.into_iter());
+    }
+
     pub(crate) fn pop_front(&mut self) -> Option<Value<'lua>> {
         self.0.pop()
+    }
+
+    pub(crate) fn drop_front(&mut self, count: usize) {
+        self.0.drain(self.0.len() - count..).count();
     }
 
     pub fn len(&self) -> usize {
@@ -179,5 +187,9 @@ pub trait FromLuaMulti<'lua>: Sized {
     /// values should be ignored. This reflects the semantics of Lua when calling a function or
     /// assigning values. Similarly, if not enough values are given, conversions should assume that
     /// any missing values are nil.
-    fn from_lua_multi(values: MultiValue<'lua>, lua: Context<'lua>) -> Result<Self>;
+    fn from_lua_multi(
+        values: MultiValue<'lua>,
+        lua: Context<'lua>,
+        consumed: &mut usize,
+    ) -> Result<Self>;
 }


### PR DESCRIPTION
This PR adds ability to compose `FromLuaMulti` values which makes it convenient to add functions which consume arguments of different _kinds_.

This places an additional requirement on user implementing FromLuaMulti to mutate `consumed` argument with the number of arguments that were consumed from provided _remaining arguments_.

I'm not too happy with complexity added by this feature, but it significantly simplifies my workflow in a case where I have to consume arguments in form `(&[(f32, f32)], bool)` and the tuple is supposed to be flattened. The only place that _cares_ about this additional argument is `impl_tuples` trait.
- I decided to add it as a `&mut usize` argument instead of return type as I think that's more convenient for implementers, as it allows gradual mutation of the usage counter instead of having to provide their own. It also provides argument location (didn't test that though).

## Usage

```rust
pub struct FromLuaPoint {
  x: f32,
  y: f32,
}

impl<'lua> FromLuaMulti<'lua> for FromLuaPoint {
  fn from_lua_multi(
        values: LuaMultiValue<'lua>,
        lua: LuaContext<'lua>,
        consumed: &mut usize,
    ) -> LuaResult<Self> {
      match values.next() {
        LuaValue::Number(x) => {
          // consume another...
          *consumed += 2;
          return Ok(FromLuaPoint{ x: x as f32, y: y as f32 })
        }
        LuaValue::Table(table) => {
          // process table...
          *consumed += 1;
          return Ok(FromLuaPoint{ x: table_x, y: table_y })
        }
        _ => {
          // return error when missing arguments, bad arguments, or some other issue...
          return Err(LuaError);
        }
      }
    }
}

methods.add_method("addPoint", |_, this, (point, color): (FromLuaPoint, FromLuaColor)| {
  // do something with point and color parsed from LuaMultiValue
  println!("Added point: {}, {}", point.x, point.y);
});
```

```lua
UserData:addPoint(x, y, color_str)
UserData:addPoint(x, y, r, g, b, a)
UserData:addPoint({x, y}, r, g, b, a)
UserData:addPoint({x = x, y = y}, r, g, b, a)
```

## Breaking changes

`FromLuaMulti::from_lua_multi` takes an additional `consumed: &mut usize` argument.